### PR TITLE
Develop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: setup docker
         uses: docker/setup-buildx-action@v2
       - name: docker pull
@@ -42,7 +42,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Check out repo under workspace
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: setup docker
         uses: docker/setup-buildx-action@v2
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ texファイルのdocumentclassでecoではなくb3-ecoを指定してくださ�
 ```
 ゼミ用テンプレートに戻すにはecoを指定
 ```
-\documentclass[submit,techreq,noauthor,dvipdfmx]{b3-eco}
+\documentclass[submit,techreq,noauthor,dvipdfmx]{eco}
 ```
 
 ## textlint

--- a/latex-setting/file-explorer.sh
+++ b/latex-setting/file-explorer.sh
@@ -1,10 +1,12 @@
-#!/bin/bash -eux
+#!/bin/bash
+
+# set -e
 
 # 最後に更新されたtexファイルを探索
-# vscodeからは編集中のtexファイルを取得できないため作成
 
 tex_files=()
-tex_files+=($(readlink -f $(find ../ -name "*.tex" -type f)))
+tex_files+=($(readlink -f $(find . -name "*.tex" -type f)))
+
 
 file_date=()
 file_date+=($(stat ${tex_files[@]} | grep Modify | cut -d " " -f 2,3 | sed -e "s@ @@g" -e "s@-@@g" -e "s@:@@g" -e "s@@@g"))

--- a/makefile
+++ b/makefile
@@ -145,14 +145,6 @@ _postBuild:
 
 
 install:
-ifeq ($(shell ls | grep -c workspace),0)
-	mkdir workspace
-endif
-ifeq ($(shell ls workspace/ 2>/dev/null | grep -c ".tex"),0)
-	cp sample/*.tex workspace/
-	touch workspace/references.bib
-	bash sample-clean.sh
-endif
 ifeq ($(shell docker --version 2>/dev/null),)
 ifeq (${IS_LINUX},Linux)
 	-make install-docker


### PR DESCRIPTION
ホームディレクトリ直下にsemi-latexを配置した場合，ホームディレクトリ内すべてがtexの検索対象になる問題を修正
任意のディレクトリでビルドが可能になったのでworkspaceを廃止