### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ make docker-clean
   ```
 
 ## インストール
-* workspaceディレクトリの作成とtexファイル, bibtexファイルを作成する
 * Dockerがインストールされていない場合はインストールする
   * Linux限定
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@
 1. 環境をインストール
    * **Ubuntuのみ**Docker環境を自動インストール
     * Mac OS, Windowsは個別にDockerとmakeの実行環境を作ってください
+      * M1, M2では多分動作しません
     ```
     make install
     ```
@@ -121,6 +122,32 @@ make lint
     * epsへ自動変換
   * svg
     * pdfへ自動変換
+* 自動変換の注意
+  * 画像用のディレクトリを作成し，すべての画像を同じディレクトリに入れる
+    * ディレクトリ名は任意
+  * 作成したディレクトリ内でネストしない
+  * フォルダ階層の例
+    ```
+    sample.tex
+    fig/
+    |--hoge.png
+    |--huga.svg
+    ```
+  * NG
+    * ディレクトリがネスト
+    ```
+    sample.tex
+    fig/
+    |--fig/
+        |--hoge.png
+        |--huga.svg
+    ```
+    * ディレクトリに保存されていない
+    ```
+    sample.tex
+    hoge.png
+    huga.svg
+    ```
 ### png
 * 拡張子は.pngではなく.epsを指定
   * コンテナ内で自動的にpngからepsを生成するため

--- a/latex-setting/Makefile
+++ b/latex-setting/Makefile
@@ -78,7 +78,7 @@ endif
 TIMESTAMP := $(shell date +%Y%m%d)
 
 ## Define dependent files to generate DVI file
-SRC-FIGURE-DIRS := fig
+SRC-FIGURE-DIRS := $(shell find . -name "*.png" -or -name "*.eps" -or -name "*.svg" | cut -d "/" -f 2 | head -n1)
 SRC-OBJ := $(wildcard $(addsuffix /*.obj,$(SRC-FIGURE-DIRS))) # Tgif files
 SRC-SVG := $(wildcard $(addsuffix /*.svg,$(SRC-FIGURE-DIRS))) # Inkscape files
 SRC-PNG := $(wildcard $(addsuffix /*.png,$(SRC-FIGURE-DIRS))) # Some pictures

--- a/media/semi-rule.yml
+++ b/media/semi-rule.yml
@@ -89,3 +89,7 @@ rules:
     pattern: リアルタム
   - expected: 調査
     pattern: 超うさ
+  - expected: Windows
+    pattern: windows
+  - expected: Linux
+    pattern: linux


### PR DESCRIPTION
画像の自動変換をするディレクトリがfigで固定されていたので任意のディレクトリを使用可能に変更
LintルールにWindows, Linuxを追加